### PR TITLE
Update duckdb

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -23,7 +23,7 @@ jobs:
             container: 'quay.io/pypa/manylinux2014_x86_64'
             vcpkg_triplet: 'x64-linux'
           - arch: 'linux_amd64'
-            container: 'ubuntu:16.04'
+            container: 'ubuntu:18.04'
             vcpkg_triplet: 'x64-linux'
           - arch: 'linux_arm64'
             container: 'ubuntu:18.04'
@@ -60,24 +60,27 @@ jobs:
         fetch-depth: 0
         submodules: 'true'
 
-    - name: install npm
+    - name: install Azure test service
       if: ${{ matrix.arch == 'linux_amd64_gcc4' }}
       run: |
         yum install -y nodejs npm
+        npm install -g azurite
+        echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" | tee /etc/yum.repos.d/azure-cli.repo
+        yum install -y azure-cli
 
-    - name: install npm
+    - name: install Azure test service
       if: ${{ matrix.arch == 'linux_amd64' }}
       run: |
         curl -fsSL https://deb.nodesource.com/setup_16.x | bash
         apt-get install -y -qq nodejs
         node -v 
         npm -v
+        npm install -g azurite
+        curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
     - name: Launch & populate Azure test service
       if: ${{ matrix.arch == 'linux_amd64' || matrix.arch == 'linux_amd64_gcc4' }}
       run: |
-        npm install -g azurite
-        curl -sL https://aka.ms/InstallAzureCLIDeb | bash
         azurite > azurite_log.txt 2>&1 &
         sleep 10
         ./scripts/upload_test_files_to_azurite.sh
@@ -95,7 +98,7 @@ jobs:
 
     - name: Setup Ubuntu
       if: ${{ matrix.arch == 'linux_amd64' || matrix.arch == 'linux_arm64' }}
-      uses: ./duckdb/.github/actions/ubuntu_16_setup
+      uses: ./duckdb/.github/actions/ubuntu_18_setup
       with:
         aarch64_cross_compile: 1
 
@@ -114,9 +117,10 @@ jobs:
       run: |
         make release
 
-    # Some issues with azurite on linux remain for some reason
+    # Todo: fix azurite crashing on ubuntu when testing
     - name: Test extension
-      if: ${{ matrix.arch == 'linux_amd64_gcc4'}}
+#      if: ${{ matrix.arch == 'linux_amd64_gcc4' || matrix.arch == 'linux_amd64'}}
+      if: ${{ matrix.arch == 'linux_amd64_gcc4' }}
       run: |
         make test
 

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -61,6 +61,11 @@ jobs:
         submodules: 'true'
 
     - name: install npm
+      if: ${{ matrix.arch == 'linux_amd64_gcc4' }}
+      run: |
+        yum install -y nodejs npm
+
+    - name: install npm
       if: ${{ matrix.arch == 'linux_amd64' }}
       run: |
         curl -fsSL https://deb.nodesource.com/setup_16.x | bash
@@ -69,7 +74,7 @@ jobs:
         npm -v
 
     - name: Launch & populate Azure test service
-      if: ${{ matrix.arch == 'linux_amd64' }}
+      if: ${{ matrix.arch == 'linux_amd64' || matrix.arch == 'linux_amd64_gcc4' }}
       run: |
         npm install -g azurite
         curl -sL https://aka.ms/InstallAzureCLIDeb | bash
@@ -110,10 +115,10 @@ jobs:
         make release
 
     # Some issues with azurite on linux remain for some reason
-#    - name: Test extension
-#      if: ${{ matrix.arch == 'linux_amd64'}}
-#      run: |
-#        make test
+    - name: Test extension
+      if: ${{ matrix.arch == 'linux_amd64_gcc4'}}
+      run: |
+        make test
 
     - uses: actions/upload-artifact@v2
       with:
@@ -145,8 +150,8 @@ jobs:
           ./scripts/extension-upload.sh azure `git log -1 --format=%h` $DUCKDB_VERSION ${{matrix.arch}} $BUCKET_NAME false
         fi
 
-#    - name: Azure test server log
-#      if: always() && matrix.arch == 'linux_amd64'
-#      shell: bash
-#      run: |
-#        cat azurite_log.txt
+    - name: Azure test server log
+      if: always() && matrix.arch == 'linux_amd64_gcc4'
+      shell: bash
+      run: |
+        cat azurite_log.txt

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-Warning: this extension is currently in an experimental state. Feel free to try it out, but be aware
-that only minimal testing was done and no benchmarking.
-
-Warning 2: This extension currently builds with a feature branch of DuckDB. A PR is being worked on. When the PR is merged,
-this extension will be included in (nightly) DuckDB releases.
+## Experimental warning
+This extension is currently in an experimental state. Feel free to try it out, but be aware some things
+may not work as expected.
 
 # DuckDB Azure Extension
 This extension adds a filesystem abstraction for Azure blob storage to DuckDB.


### PR DESCRIPTION
also enable the azurite test server on manylinux builds, ubuntu build testing with azurite is disabled for now due to some weird issue where azurite returns http 500 errors